### PR TITLE
Update Thorim range check to the correct value of 8 yards

### DIFF
--- a/DBM-Ulduar/Thorim.lua
+++ b/DBM-Ulduar/Thorim.lua
@@ -42,7 +42,7 @@ local timerLightningCharge	 		= mod:NewCDTimer(16, 62466, nil, nil, nil, 3)
 local timerUnbalancingStrike		= mod:NewCDTimer(25.6, 62130, nil, "Tank", nil, 5, nil, DBM_COMMON_L.TANK_ICON)
 local timerHardmode					= mod:NewTimer(175, "TimerHardmode", 62042)
 
-mod:AddRangeFrameOption("10")
+mod:AddRangeFrameOption("8")
 mod:AddSetIconOption("SetIconOnBomb", 62526, false, false, {7})
 
 local lastcharge = {}
@@ -52,7 +52,7 @@ function mod:OnCombatStart(delay)
 	enrageTimer:Start()
 	timerHardmode:Start()
 	if self.Options.RangeFrame then
-		DBM.RangeCheck:Show(10)
+		DBM.RangeCheck:Show(8)
 	end
 	table.wipe(lastcharge)
 end


### PR DESCRIPTION
The Classic range options in raids allow for 8 yards, and it is an 8 yard ability according to the wago.tools database EffectChainTargets value of "8". This can also be seen ingame when a player is in the 10yd range indicator and chain lightning does not bounce to them. This is mostly problematic in stratrgies for melee, that have a false sense of positioning to both attack the boss and not destroy your raid.

The https://wago.tools/db2/SpellEffect\?build\=3.4.1.48632\&filter\[SpellID\]\=64390\&page\=1 link shows an 8 for `EffectChainTargets`, which seems to be the effective bounce chain range.