### PR TITLE
Fix ICC and Ulduar encounter IDs for post-cata classic client

### DIFF
--- a/DBM-Raids-WoTLK/Coliseum/Anubarak.lua
+++ b/DBM-Raids-WoTLK/Coliseum/Anubarak.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(34564)
-mod:SetEncounterID(mod:IsClassic() and 645 or 1085)
+mod:SetEncounterID(not mod:IsPostCata() and 645 or 1085)
 mod:SetModelID(29268)
 mod:SetUsedIcons(1, 2, 3, 4, 5, 8)
 mod:SetHotfixNoticeRev(20230817000000)

--- a/DBM-Raids-WoTLK/Coliseum/Champions.lua
+++ b/DBM-Raids-WoTLK/Coliseum/Champions.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(34458, 34451, 34459, 34448, 34449, 34445, 34456, 34447, 34441, 34454, 34444, 34455, 34450, 34453, 34461, 34460, 34469, 34467, 34468, 34471, 34465, 34466, 34473, 34472, 34470, 34463, 34474, 34475)
---mod:SetEncounterID(mod:IsClassic() and 637 or 1086)--This must never be enabled
+--mod:SetEncounterID(not mod:IsPostCata() and 637 or 1086)--This must never be enabled
 mod:SetBossHPInfoToHighest()
 
 mod:RegisterCombat("combat")

--- a/DBM-Raids-WoTLK/Coliseum/Jaraxxus.lua
+++ b/DBM-Raids-WoTLK/Coliseum/Jaraxxus.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(34780)
-mod:SetEncounterID(mod:IsClassic() and 633 or 1087)
+mod:SetEncounterID(not mod:IsPostCata() and 633 or 1087)
 mod:SetModelID(29615)
 mod:SetMinCombatTime(30)
 mod:SetUsedIcons(7, 8)

--- a/DBM-Raids-WoTLK/Coliseum/NorthrendBeasts.lua
+++ b/DBM-Raids-WoTLK/Coliseum/NorthrendBeasts.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(34796, 35144, 34799, 34797)
---mod:SetEncounterID(mod:IsClassic() and 629 or 1088)--Buggy, never enable this
+--mod:SetEncounterID(not mod:IsPostCata() and 629 or 1088)--Buggy, never enable this
 mod:SetMinSyncRevision(104)
 mod:SetModelID(21601)
 mod:SetMinCombatTime(30)

--- a/DBM-Raids-WoTLK/Coliseum/Twins.lua
+++ b/DBM-Raids-WoTLK/Coliseum/Twins.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(34497, 34496)
-mod:SetEncounterID(mod:IsClassic() and 641 or 1089)
+mod:SetEncounterID(not mod:IsPostCata() and 641 or 1089)
 mod:SetModelID(29240)
 mod:SetMinCombatTime(30)
 mod:SetUsedIcons(1, 2, 3, 4)

--- a/DBM-Raids-WoTLK/Icecrown/FrostwingHalls/Sindragosa.lua
+++ b/DBM-Raids-WoTLK/Icecrown/FrostwingHalls/Sindragosa.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(36853)
-mod:SetEncounterID(mod:IsClassic() and 855 or 1105)
+mod:SetEncounterID(not mod:IsPostCata() and 855 or 1105)
 mod:SetModelID(30362)
 mod:SetUsedIcons(1, 2, 3, 4, 5, 6, 7)
 mod:SetMinSyncRevision(20220623000000)

--- a/DBM-Raids-WoTLK/Icecrown/FrostwingHalls/Valithria.lua
+++ b/DBM-Raids-WoTLK/Icecrown/FrostwingHalls/Valithria.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(36789)
-mod:SetEncounterID(mod:IsClassic() and 854 or 1098)
+mod:SetEncounterID(not mod:IsPostCata() and 854 or 1098)
 mod:SetModelID(30318)
 mod:SetUsedIcons(8)
 mod.onlyHighest = true--Instructs DBM health tracking to literally only store highest value seen during fight, even if it drops below that

--- a/DBM-Raids-WoTLK/Icecrown/TheCrimsonHall/BPCouncil.lua
+++ b/DBM-Raids-WoTLK/Icecrown/TheCrimsonHall/BPCouncil.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(37970, 37972, 37973)
-mod:SetEncounterID(mod:IsClassic() and 852 or 1095)
+mod:SetEncounterID(not mod:IsPostCata() and 852 or 1095)
 mod:DisableEEKillDetection()--IEEU fires for this boss.
 mod:SetModelID(30858)
 mod:SetUsedIcons(7, 8)

--- a/DBM-Raids-WoTLK/Icecrown/TheCrimsonHall/Lanathel.lua
+++ b/DBM-Raids-WoTLK/Icecrown/TheCrimsonHall/Lanathel.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(37955)
-mod:SetEncounterID(mod:IsClassic() and 853 or 1103)
+mod:SetEncounterID(not mod:IsPostCata() and 853 or 1103)
 mod:SetModelID(31165)
 mod:SetUsedIcons(1, 2, 3, 4, 7)
 

--- a/DBM-Raids-WoTLK/Icecrown/TheFrozenThrone/LichKing.lua
+++ b/DBM-Raids-WoTLK/Icecrown/TheFrozenThrone/LichKing.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(36597)
-mod:SetEncounterID(mod:IsClassic() and 856 or 1106)
+mod:SetEncounterID(not mod:IsPostCata() and 856 or 1106)
 mod:DisableEEKillDetection()--EE fires at 10%
 mod:SetModelID(30721)
 mod:SetUsedIcons(1, 2, 3, 4, 5, 6, 7)

--- a/DBM-Raids-WoTLK/Icecrown/TheLowerSpire/Deathbringer.lua
+++ b/DBM-Raids-WoTLK/Icecrown/TheLowerSpire/Deathbringer.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(37813)
-mod:SetEncounterID(mod:IsClassic() and 848 or 1096)
+mod:SetEncounterID(not mod:IsPostCata() and 848 or 1096)
 mod:SetModelID(30790)
 mod:SetUsedIcons(1, 2, 3, 4, 5, 6, 7, 8)
 

--- a/DBM-Raids-WoTLK/Icecrown/TheLowerSpire/Deathwhisper.lua
+++ b/DBM-Raids-WoTLK/Icecrown/TheLowerSpire/Deathwhisper.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(36855)
-mod:SetEncounterID(mod:IsClassic() and 846 or 1100)
+mod:SetEncounterID(not mod:IsPostCata() and 846 or 1100)
 mod:SetModelID(30893)
 mod:SetUsedIcons(1, 2, 3, 7, 8)
 mod:RegisterCombat("combat")

--- a/DBM-Raids-WoTLK/Icecrown/TheLowerSpire/GunshipBattle.lua
+++ b/DBM-Raids-WoTLK/Icecrown/TheLowerSpire/GunshipBattle.lua
@@ -6,7 +6,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 mod:SetRevision("@file-date-integer@")
 local addsIcon
 local bossID
-mod:SetEncounterID(mod:IsClassic() and 847 or 1099)--No ES fires this combat
+mod:SetEncounterID(not mod:IsPostCata() and 847 or 1099)--No ES fires this combat
 mod:SetCreatureID(37215, 37540) -- Orgrim's Hammer, The Skybreaker
 mod:SetMinSyncRevision(119)
 if UnitFactionGroup("player") == "Alliance" then

--- a/DBM-Raids-WoTLK/Icecrown/TheLowerSpire/LordMarrowgar.lua
+++ b/DBM-Raids-WoTLK/Icecrown/TheLowerSpire/LordMarrowgar.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(36612)
-mod:SetEncounterID(mod:IsClassic() and 845 or 1101)
+mod:SetEncounterID(not mod:IsPostCata() and 845 or 1101)
 mod:SetModelID(31119)
 mod:SetUsedIcons(2, 3, 4, 5, 6, 7, 8)
 

--- a/DBM-Raids-WoTLK/Icecrown/ThePlagueworks/Festergut.lua
+++ b/DBM-Raids-WoTLK/Icecrown/ThePlagueworks/Festergut.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(36626)
-mod:SetEncounterID(mod:IsClassic() and 849 or 1097)
+mod:SetEncounterID(not mod:IsPostCata() and 849 or 1097)
 mod:SetModelID(31006)
 mod:RegisterCombat("combat")
 mod:SetUsedIcons(1, 2, 3)

--- a/DBM-Raids-WoTLK/Icecrown/ThePlagueworks/Putricide.lua
+++ b/DBM-Raids-WoTLK/Icecrown/ThePlagueworks/Putricide.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(36678)
-mod:SetEncounterID(mod:IsClassic() and 851 or 1102)
+mod:SetEncounterID(not mod:IsPostCata() and 851 or 1102)
 mod:SetModelID(30881)
 mod:SetUsedIcons(1, 2, 3, 4)
 --mod:SetMinSyncRevision(3860)

--- a/DBM-Raids-WoTLK/Icecrown/ThePlagueworks/Rotface.lua
+++ b/DBM-Raids-WoTLK/Icecrown/ThePlagueworks/Rotface.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(36627)
-mod:SetEncounterID(mod:IsClassic() and 850 or 1104)
+mod:SetEncounterID(not mod:IsPostCata() and 850 or 1104)
 mod:SetModelID(31005)
 mod:SetUsedIcons(1, 2)
 mod:RegisterCombat("combat")

--- a/DBM-Raids-WoTLK/RubySanctum/Baltharus.lua
+++ b/DBM-Raids-WoTLK/RubySanctum/Baltharus.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(39751)
-mod:SetEncounterID(mod:IsClassic() and 890 or 1147)
+mod:SetEncounterID(not mod:IsPostCata() and 890 or 1147)
 mod:SetModelID(31761)
 mod:SetUsedIcons(1, 2, 3, 4, 5, 6, 7, 8)
 

--- a/DBM-Raids-WoTLK/RubySanctum/Halion.lua
+++ b/DBM-Raids-WoTLK/RubySanctum/Halion.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(39863)--40142 (twilight form)
-mod:SetEncounterID(mod:IsClassic() and 887 or 1150)
+mod:SetEncounterID(not mod:IsPostCata() and 887 or 1150)
 mod:SetModelID(31952)
 mod:SetUsedIcons(7, 3)
 mod:SetHotfixNoticeRev(20240113000000)

--- a/DBM-Raids-WoTLK/RubySanctum/Saviana.lua
+++ b/DBM-Raids-WoTLK/RubySanctum/Saviana.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(39747)
-mod:SetEncounterID(mod:IsClassic() and 891 or 1149)
+mod:SetEncounterID(not mod:IsPostCata() and 891 or 1149)
 mod:SetModelID(31577)
 mod:SetUsedIcons(8, 7, 6, 5, 4)
 

--- a/DBM-Raids-WoTLK/RubySanctum/Zarithrian.lua
+++ b/DBM-Raids-WoTLK/RubySanctum/Zarithrian.lua
@@ -5,7 +5,7 @@ mod.statTypes = "normal,normal25,heroic,heroic25"
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(39746)
-mod:SetEncounterID(mod:IsClassic() and 893 or 1148)
+mod:SetEncounterID(not mod:IsPostCata() and 893 or 1148)
 mod:SetModelID(32179)
 
 mod:RegisterCombat("combat")

--- a/DBM-Raids-WoTLK/Ulduar/Algalon.lua
+++ b/DBM-Raids-WoTLK/Ulduar/Algalon.lua
@@ -7,7 +7,7 @@ end
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(32871)
-if not mod:IsClassic() then--Assumed fixed in classic
+if mod:IsPostCata() then--Assumed fixed in classic
 	mod:SetEncounterID(1130)
 	mod:DisableEEKillDetection()--EE always fires wipe
 else

--- a/DBM-Raids-WoTLK/Ulduar/Auriaya.lua
+++ b/DBM-Raids-WoTLK/Ulduar/Auriaya.lua
@@ -8,7 +8,7 @@ end
 mod:SetRevision("@file-date-integer@")
 
 mod:SetCreatureID(33515)--34014--Add this (kitties) to pull detection when it can be ignored in kill
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1131)
 else
 	mod:SetEncounterID(750)

--- a/DBM-Raids-WoTLK/Ulduar/FlameLeviathan.lua
+++ b/DBM-Raids-WoTLK/Ulduar/FlameLeviathan.lua
@@ -8,7 +8,7 @@ end
 mod:SetRevision("@file-date-integer@")
 
 mod:SetCreatureID(33113)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1132)
 else
 	mod:SetEncounterID(744)

--- a/DBM-Raids-WoTLK/Ulduar/Freya.lua
+++ b/DBM-Raids-WoTLK/Ulduar/Freya.lua
@@ -8,7 +8,7 @@ end
 mod:SetRevision("@file-date-integer@")
 
 mod:SetCreatureID(32906)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1133)
 else
 	mod:SetEncounterID(753)

--- a/DBM-Raids-WoTLK/Ulduar/GeneralVezax.lua
+++ b/DBM-Raids-WoTLK/Ulduar/GeneralVezax.lua
@@ -7,7 +7,7 @@ end
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(33271)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1134)
 else
 	mod:SetEncounterID(755)

--- a/DBM-Raids-WoTLK/Ulduar/Hodir.lua
+++ b/DBM-Raids-WoTLK/Ulduar/Hodir.lua
@@ -7,7 +7,7 @@ end
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(32845,32926)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1135)
 else
 	mod:SetEncounterID(751)

--- a/DBM-Raids-WoTLK/Ulduar/Ignis.lua
+++ b/DBM-Raids-WoTLK/Ulduar/Ignis.lua
@@ -7,7 +7,7 @@ end
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(33118)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1136)
 else
 	mod:SetEncounterID(745)

--- a/DBM-Raids-WoTLK/Ulduar/IronCouncil.lua
+++ b/DBM-Raids-WoTLK/Ulduar/IronCouncil.lua
@@ -8,7 +8,7 @@ end
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(32867, 32927, 32857)
 mod:SetEncounterID(1140)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1140)
 	mod:DisableEEKillDetection()--Fires for first one dying not last
 else

--- a/DBM-Raids-WoTLK/Ulduar/Kologarn.lua
+++ b/DBM-Raids-WoTLK/Ulduar/Kologarn.lua
@@ -7,7 +7,7 @@ end
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(32930)--, 32933, 32934
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1137)
 else
 	mod:SetEncounterID(749)

--- a/DBM-Raids-WoTLK/Ulduar/Mimiron.lua
+++ b/DBM-Raids-WoTLK/Ulduar/Mimiron.lua
@@ -7,7 +7,7 @@ end
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(33432)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1138)
 else
 	mod:SetEncounterID(754)

--- a/DBM-Raids-WoTLK/Ulduar/Razorscale.lua
+++ b/DBM-Raids-WoTLK/Ulduar/Razorscale.lua
@@ -7,7 +7,7 @@ end
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(33186)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1139)
 else
 	mod:SetEncounterID(746)

--- a/DBM-Raids-WoTLK/Ulduar/Thorim.lua
+++ b/DBM-Raids-WoTLK/Ulduar/Thorim.lua
@@ -7,7 +7,7 @@ end
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(32865)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1141)
 else
 	mod:SetEncounterID(752)

--- a/DBM-Raids-WoTLK/Ulduar/XT002.lua
+++ b/DBM-Raids-WoTLK/Ulduar/XT002.lua
@@ -7,7 +7,7 @@ end
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(33293)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1142)
 else
 	mod:SetEncounterID(747)

--- a/DBM-Raids-WoTLK/Ulduar/YoggSaron.lua
+++ b/DBM-Raids-WoTLK/Ulduar/YoggSaron.lua
@@ -7,7 +7,7 @@ end
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(33288)
-if not mod:IsClassic() then
+if mod:IsPostCata() then
 	mod:SetEncounterID(1143)
 else
 	mod:SetEncounterID(756)

--- a/DBM-Raids-WoTLK/VoA/Archavon.lua
+++ b/DBM-Raids-WoTLK/VoA/Archavon.lua
@@ -3,7 +3,7 @@ local L		= mod:GetLocalizedStrings()
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(31125)
-mod:SetEncounterID(mod:IsClassic() and 772 or 1126)
+mod:SetEncounterID(not mod:IsPostCata() and 772 or 1126)
 mod:SetModelID(26967)
 
 mod:RegisterCombat("combat")

--- a/DBM-Raids-WoTLK/VoA/Emalon.lua
+++ b/DBM-Raids-WoTLK/VoA/Emalon.lua
@@ -3,7 +3,7 @@ local L		= mod:GetLocalizedStrings()
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(33993)
-mod:SetEncounterID(mod:IsClassic() and 774 or 1127)
+mod:SetEncounterID(not mod:IsPostCata() and 774 or 1127)
 mod:SetModelID(27108)
 mod:SetUsedIcons(8)
 

--- a/DBM-Raids-WoTLK/VoA/Koralon.lua
+++ b/DBM-Raids-WoTLK/VoA/Koralon.lua
@@ -3,7 +3,7 @@ local L		= mod:GetLocalizedStrings()
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(35013)
-mod:SetEncounterID(mod:IsClassic() and 776 or 1128)
+mod:SetEncounterID(not mod:IsPostCata() and 776 or 1128)
 mod:SetModelID(29524)
 
 mod:RegisterCombat("combat")

--- a/DBM-Raids-WoTLK/VoA/Toravon.lua
+++ b/DBM-Raids-WoTLK/VoA/Toravon.lua
@@ -3,7 +3,7 @@ local L		= mod:GetLocalizedStrings()
 
 mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(38433)
-mod:SetEncounterID(mod:IsClassic() and 885 or 1129)
+mod:SetEncounterID(not mod:IsPostCata() and 885 or 1129)
 mod:SetModelID(31089)
 
 mod:RegisterCombat("combat")


### PR DESCRIPTION
`mod:IsClassic()` returns true for Cata Classic (rightfully), but that caused some mods to use the outdated encounter IDs.